### PR TITLE
fix for empy comments causing pydantic validation error

### DIFF
--- a/regrws/models/nested.py
+++ b/regrws/models/nested.py
@@ -39,7 +39,7 @@ class Iso31661(BaseModel, tag="iso3166-1", nsmap=NSMAP):
 
 class MultiLineElement(BaseModel):
     number: int = attr()
-    line: str
+    line: str | None = ''
 
 
 class Attachment(BaseModel, tag="attachment", nsmap=NSMAP):

--- a/tests/payloads.py
+++ b/tests/payloads.py
@@ -12,11 +12,15 @@ POC_PAYLOAD = \
         </emails>
         <streetAddress>
             <line number = "1">Line 1</line>
+            <line number = "2"></line>
+            <line number = "3">Line 3</line>
         </streetAddress>
         <city>Chantilly</city>
         <postalCode>20151</postalCode>
         <comment>
             <line number = "1">Line 1</line>
+            <line number = "2"></line>
+            <line number = "3">Line 3</line>
         </comment>
         <registrationDate>Mon Nov 07 14:04:28 EST 2011</registrationDate>
         <handle>ARIN-HOSTMASTER</handle>
@@ -47,12 +51,16 @@ ORG_PAYLOAD = \
         </iso3166-1>
         <streetAddress>
             <line number = "1">Line 1</line>
+            <line number = "2"></line>
+            <line number = "3">Line 3</line>
         </streetAddress>
         <city>Chantilly</city>
         <iso3166-2>VA</iso3166-2>
         <postalCode>20151</postalCode>
         <comment>
             <line number = "1">Line 1</line>
+            <line number = "2"></line>
+            <line number = "3">Line 3</line>
         </comment>
         <handle>ARIN</handle>
         <registrationDate>Mon Nov 07 14:04:28 EST 2011</registrationDate>
@@ -78,12 +86,16 @@ CUSTOMER_PAYLOAD = \
         <handle>C1241523</handle>
         <streetAddress>
             <line number = "1">Line 1</line>
+            <line number = "2"></line>
+            <line number = "3">Line 3</line>
         </streetAddress>
         <city>Chantilly</city>
             <iso3166-2>VA</iso3166-2>
         <postalCode>20151</postalCode>
         <comment>
             <line number = "1">Line 1</line>
+            <line number = "2"></line>
+            <line number = "3">Line 3</line>
         </comment>
         <handle>CUST</handle>
         <parentOrgHandle>PARENTORGHANDLE</parentOrgHandle>
@@ -105,6 +117,8 @@ NET_PAYLOAD = \
         <version>4</version>
         <comment>
             <line number = "1">Line 1</line>
+            <line number = "2"></line>
+            <line number = "3">Line 3</line>
         </comment>
         <registrationDate>Tue Jan 25 16:17:18 EST 2011</registrationDate>
         <handle>NET-10-0-0-0-1</handle>
@@ -155,6 +169,8 @@ TICKET_PAYLOAD = \
                 <subject>SUBJECT</subject>
                     <text>
                         <line number = "1">Line 1</line>
+                        <line number = "2"></line>
+                        <line number = "3">Line 3</line>
                     </text>
                 <category>NONE</category>
                 <attachments>


### PR DESCRIPTION
Empty comments were causing pydantic validation errors:
```
1 validation error for Net
comment -> 1 -> line
  field required (type=value_error.missing)
  File "/home/nate/arin/arin-pyregrws.py", line 14, in <module>
    parent = a.net.find_parent(start_address=start, end_address=end)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic.error_wrappers.ValidationError: 1 validation error for Net
comment -> 1 -> line
  field required (type=value_error.missing)
  ```
  
  This fix allows empty MultiLineElements and adds them to the tests.