### PR TITLE
Send Content-Type on POST, PUT

### DIFF
--- a/regrws/api/manager.py
+++ b/regrws/api/manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
 
+from regrws.api import constants
 from regrws.api.core import Response
 
 
@@ -47,7 +48,7 @@ class BaseManager:
         with Session(handlers) as session:  # type: ignore
             headers = {}
             if verb in ('post', 'put'):
-                headers['Content-Type'] = 'application/xml'
+                headers['Content-Type'] = constants.CONTENT_TYPE
             session_method = getattr(session, verb)
             res: Response = session_method(url, headers=headers, params=self.url_params, data=data)  # type: ignore
             res.raise_for_unknown_status()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 import pytest
 import responses
+from responses.matchers import header_matcher
 
 from regrws.api import constants
 from regrws.api.core import Api
@@ -70,6 +71,7 @@ class TestAPI:
             body=payload.encode(),
             status=200,
             content_type=constants.CONTENT_TYPE,
+            match=[header_matcher({"Content-Type": "application/xml"})],
         )
 
         instance.save()
@@ -106,6 +108,7 @@ class TestAPI:
             body=payload.encode(),
             status=200,
             content_type=constants.CONTENT_TYPE,
+            match=[header_matcher({"Content-Type": "application/xml"})],
         )
 
         new_insance = manager.create(**instance.dict())

--- a/tests/test_custom_managers.py
+++ b/tests/test_custom_managers.py
@@ -1,5 +1,6 @@
 import pytest
 import responses
+from responses.matchers import header_matcher
 
 from regrws.api import Api, constants
 from regrws.models.customer import Customer
@@ -36,6 +37,7 @@ def test_cust_manager(mocked_responses, api: type[Api]):
         body=CUSTOMER_PAYLOAD.encode(),
         status=200,
         content_type=constants.CONTENT_TYPE,
+        match=[header_matcher({"Content-Type": "application/xml"})],
     )
     net = api.net.from_handle(handle="Net-10-0-0-0-1")
     customer = Customer.from_xml(CUSTOMER_PAYLOAD)
@@ -55,6 +57,7 @@ def test_org_manager(mocked_responses, api: type[Api]):
         body=TICKET_PAYLOAD.encode(),
         status=200,
         content_type=constants.CONTENT_TYPE,
+        match=[header_matcher({"Content-Type": "application/xml"})],
     )
     instance = api.org.from_handle(handle="ARIN")
     assert instance is not None, "Instance should not be None"
@@ -93,18 +96,21 @@ def test_net_manager(mocked_responses, api: type[Api]):
         body=TICKETED_REQUEST_PAYLOAD.encode(),
         status=200,
         content_type=constants.CONTENT_TYPE,
+        match=[header_matcher({"Content-Type": "application/xml"})],
     )
     mocked_responses.put(
         "https://reg.ote.arin.net/rest/net/NET-10-0-0-0-1/reassign?apikey=APIKEY",
         body=TICKETED_REQUEST_PAYLOAD.encode(),
         status=200,
         content_type=constants.CONTENT_TYPE,
+        match=[header_matcher({"Content-Type": "application/xml"})],
     )
     mocked_responses.put(
         "https://reg.ote.arin.net/rest/net/NET-10-0-0-0-1/reallocate?apikey=APIKEY",
         body=TICKETED_REQUEST_PAYLOAD.encode(),
         status=200,
         content_type=constants.CONTENT_TYPE,
+        match=[header_matcher({"Content-Type": "application/xml"})],
     )
 
     with pytest.raises(NotImplementedError):


### PR DESCRIPTION
Content-Type: application/xml is required on POST and PUT.  Otherwise, ARIN will reject the request with a 415 status code.

Closes #92