### PR TITLE
Make Error.components default to empty list

### DIFF
--- a/regrws/models/error.py
+++ b/regrws/models/error.py
@@ -31,7 +31,7 @@ class Error(BaseModel, tag="error", nsmap=NSMAP, search_mode="unordered"):
         "E_OUTAGE",
         "E_UNSPECIFIED",
     ] = element()
-    components: List[ErrorComponent] = wrapped("components", element(tag="component"))
+    components: List[ErrorComponent] = wrapped("components", element(tag="component", default_factory=list))
     additionnal_info: List[str] = wrapped(
         "additionalInfo", element(tag="message", default_factory=list)
     )

--- a/tests/payloads.py
+++ b/tests/payloads.py
@@ -152,6 +152,8 @@ ERROR_PAYLOAD = """<error xmlns="http://www.arin.net/regrws/core/v1" >
         </additionalInfo>
     </error>"""
 
+ERROR_EMPTY_COMPONENTS_PAYLOAD = """<error xmlns="http://www.arin.net/regrws/core/v1"><additionalInfo/><code>E_AUTHENTICATION</code><components/><message>The API key is not authorized to make that request.</message></error>"""
+
 TICKET_PAYLOAD = """<ticket xmlns="http://www.arin.net/regrws/core/v1"
         xmlns:ns2="http://www.arin.net/regrws/messages/v1"
         xmlns:ns4="http://www.arin.net/regrws/shared-ticket/v1">

--- a/tests/test_xml_models.py
+++ b/tests/test_xml_models.py
@@ -7,6 +7,7 @@ from regrws.models.tickets import TicketRequest
 
 from .payloads import (
     CUSTOMER_PAYLOAD,
+    ERROR_EMPTY_COMPONENTS_PAYLOAD,
     ERROR_PAYLOAD,
     NET_PAYLOAD,
     NETBLOCK_PAYLOAD,
@@ -49,6 +50,21 @@ class TestModels:
         ).decode()
         print("\n" + instance_xml)
         assert instance_xml is not False
+
+
+class TestErrorEmptyComponents:
+    """Test that Error parses correctly when components is empty.
+
+    ARIN returns <components/> (empty) for some errors, e.g. E_AUTHENTICATION.
+    See https://github.com/jsenecal/pyregrws/issues/95
+    """
+
+    def test_from_xml(self, cov):
+        error = Error.from_xml(ERROR_EMPTY_COMPONENTS_PAYLOAD)
+        assert error.code == "E_AUTHENTICATION"
+        assert error.message == "The API key is not authorized to make that request."
+        assert error.components == []
+        assert error.additionnal_info == []
 
 
 class TestIso31661:


### PR DESCRIPTION
Closes #95

This makes it so `components` defaults to an empty list.

I'm not sure if a `None` `components` or an empty list `components` is better, so I'm submitting both.